### PR TITLE
Add unit tests for core modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,0 +1,21 @@
+import json
+import os
+from core.config_manager import ConfigManager
+
+
+def test_config_loading(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "envkey")
+    monkeypatch.setenv("API_CALL_DELAY_SECONDS", "0.5")
+    config_data = {
+        "default_temperature": 0.3,
+        "window_title": "Test App"
+    }
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps(config_data, ensure_ascii=False), encoding="utf-8")
+    manager = ConfigManager(config_file_path=str(config_file))
+    config = manager.config
+    assert config.openai_api_key == "envkey"
+    assert config.default_temperature == 0.3
+    assert config.window_title == "Test App"
+    assert config.api_call_delay_seconds == 0.5
+

--- a/tests/test_document_processor.py
+++ b/tests/test_document_processor.py
@@ -1,0 +1,25 @@
+from core.document_processor import DocumentProcessor
+from core.models import AppConfig
+
+
+def test_extract_text_from_txt(tmp_path):
+    content = "Hello world\nsecond line"
+    txt_file = tmp_path / "sample.txt"
+    txt_file.write_text(content, encoding="utf-8")
+    config = AppConfig(max_document_size_mb=1)
+    processor = DocumentProcessor(config)
+    valid, err = processor.validate_file(str(txt_file))
+    assert valid, err
+    result = processor.extract_text(str(txt_file))
+    assert result.is_success
+    assert result.extracted_text == content
+
+
+def test_validate_file_extension(tmp_path):
+    file_path = tmp_path / "bad.xyz"
+    file_path.write_text("data", encoding="utf-8")
+    processor = DocumentProcessor(AppConfig())
+    valid, err = processor.validate_file(str(file_path))
+    assert not valid
+    assert "サポートされていない" in err
+

--- a/tests/test_meeting_manager.py
+++ b/tests/test_meeting_manager.py
@@ -1,0 +1,67 @@
+import pytest
+from datetime import datetime
+
+from core.meeting_manager import MeetingManager, ParticipantInfo, ConversationEntry
+from core.models import ModelInfo, MeetingSettings, AIProvider
+from core.config_manager import initialize_config_manager
+
+
+class DummyMeetingManager(MeetingManager):
+    def initialize_participants(self, settings: MeetingSettings) -> bool:
+        self.clear_meeting_state()
+        for idx, model in enumerate(settings.participant_models):
+            key = f"p{idx}"
+            self.participants[key] = ParticipantInfo(
+                client=None,
+                name=model.name,
+                internal_key=key,
+                persona=model.persona,
+                model_info=model,
+            )
+        self.moderator = ParticipantInfo(
+            client=None,
+            name="moderator",
+            internal_key="mod",
+            persona="moderator",
+            model_info=settings.moderator_model,
+        )
+        self.state.total_rounds_expected = settings.rounds_per_ai * len(self.participants)
+        self.state.active_participant_keys = list(self.participants.keys())
+        return True
+
+    async def _make_participant_statement(self, participant: ParticipantInfo, system_prompt_context: str, ai_specific_round_num: int):
+        entry = ConversationEntry(
+            speaker=participant.name,
+            persona=participant.persona,
+            content=f"Statement {participant.name}",
+            timestamp=datetime.now(),
+            round_number=ai_specific_round_num,
+            model_name=participant.model_info.name,
+        )
+        self.state.add_conversation_entry(entry)
+        participant.total_statements += 1
+
+    async def _generate_final_summary(self, user_query: str, document_summary):
+        return "final summary"
+
+
+@pytest.mark.asyncio
+async def test_run_meeting_basic(monkeypatch):
+    monkeypatch.setenv("API_CALL_DELAY_SECONDS", "0")
+    initialize_config_manager()
+    settings = MeetingSettings(
+        participant_models=[
+            ModelInfo(name="modelA", provider=AIProvider.OPENAI, persona="p1"),
+            ModelInfo(name="modelB", provider=AIProvider.OPENAI, persona="p2"),
+        ],
+        moderator_model=ModelInfo(name="mod", provider=AIProvider.OPENAI, persona="m"),
+        rounds_per_ai=1,
+        user_query="topic",
+    )
+    manager = DummyMeetingManager()
+    result = await manager.run_meeting(settings)
+    assert result.participants_count == 2
+    assert len(result.conversation_log) == 2
+    assert result.final_summary == "final summary"
+    assert manager.state.phase == "completed"
+


### PR DESCRIPTION
## Summary
- add pytest configuration for path setup
- test ConfigManager env and file loading
- test DocumentProcessor text extraction
- test MeetingManager simple meeting flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ed7f5b9c08333a5b0599962010ad2