### PR TITLE
Implement context carry-over and vector search

### DIFF
--- a/core/context_manager.py
+++ b/core/context_manager.py
@@ -1,0 +1,60 @@
+import os
+import json
+from datetime import datetime
+from typing import List, Dict, Optional
+
+
+class ContextManager:
+    """会議の持ち越し事項（コンテキスト）を管理するクラス。"""
+
+    def __init__(self, context_dir: str = "saved_contexts"):
+        self.context_dir = context_dir
+        if not os.path.exists(self.context_dir):
+            os.makedirs(self.context_dir)
+
+    def save_carry_over(self, topic: str, unresolved_issues: str):
+        """未解決の課題をJSONファイルとして保存する。"""
+        if not unresolved_issues.strip():
+            print("持ち越し事項がないため、保存をスキップしました。")
+            return
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"context_{timestamp}.json"
+        filepath = os.path.join(self.context_dir, filename)
+        data = {
+            "topic": topic,
+            "unresolved_issues": unresolved_issues,
+            "created_at": timestamp,
+        }
+        with open(filepath, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=4)
+        print(f"持ち越し事項を {filepath} に保存しました。")
+
+    def list_carry_overs(self) -> List[Dict[str, str]]:
+        """保存されている持ち越し事項のリストを取得する。"""
+        contexts = []
+        for filename in sorted(os.listdir(self.context_dir), reverse=True):
+            if filename.endswith(".json"):
+                filepath = os.path.join(self.context_dir, filename)
+                with open(filepath, "r", encoding="utf-8") as f:
+                    try:
+                        data = json.load(f)
+                        contexts.append(
+                            {
+                                "id": filename,
+                                "display_name": f"[{data['created_at']}] {data['topic']}",
+                            }
+                        )
+                    except json.JSONDecodeError:
+                        continue
+        return contexts
+
+    def load_carry_over(self, context_id: str) -> Optional[str]:
+        """指定されたIDの持ち越し事項を読み込む。"""
+        filepath = os.path.join(self.context_dir, context_id)
+        if not os.path.exists(filepath):
+            return None
+        with open(filepath, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            return data.get("unresolved_issues")
+

--- a/core/persona_enhancer.py
+++ b/core/persona_enhancer.py
@@ -1,0 +1,61 @@
+from openai import OpenAI
+from typing import Dict, Optional
+
+
+class PersonaEnhancer:
+    def __init__(self, api_key: str):
+        self.client = OpenAI(api_key=api_key)
+
+    def enhance_persona(self, base_persona: str, topic: str, document_context: Optional[str]) -> str:
+        """基本ペルソナ、議題、資料コンテキストを基に、AIの思考を拡張するメタプロンプトを生成する。"""
+        system_prompt = (
+            """あなたは、AIアシスタントの役割（ペルソナ）を、最高のパフォーマンスが発揮できるようデザインする「AIアーキテクト」です。
+単なる役割設定ではなく、思考の深さ、広さ、そして独自性を引き出すための行動指針と制約事項を具体的に設計してください。
+出力は、AIアシスタントへの直接の指示（プロンプト）として使える形式で記述してください。"""
+        )
+
+        user_prompt = f"""
+# 基本ペルソナ
+{base_persona}
+
+# 議論の主要テーマ
+{topic}
+"""
+        if document_context:
+            user_prompt += f"""
+# 参考資料の要点
+{document_context}
+"""
+        user_prompt += """
+# AIへの行動指令設計
+以下の思考フレームワークに基づき、このAIに与えるべき詳細なペルソナと行動指令を設計してください。
+
+1.  **知識の源泉:**
+    * 提供された参考資料の要点を深く理解し、議論の基盤とすること。
+    * **最重要:** 資料の内容に限定されず、自身の持つ広範な知識（歴史的背景、海外の類似事例、定性的・定量的なデータ、学術的知見、文化的文脈など）を積極的に統合し、独自の視点を提示すること。資料はあくまで出発点であり、あなたの価値はそこからどれだけ思考を飛躍させられるかにある。
+
+2.  **思考のスタンス:**
+    * 議題に対して多角的・複眼的な視点を維持すること。例えば、経済的、技術的、倫理的、社会的インパクトなど、複数の側面から分析を行うこと。
+    * 短期的な視点と長期的な視点の両方から意見を述べること。
+
+3.  **発言のスタイル:**
+    * 具体的で、根拠のある発言を心がけること。「～だと思う」だけでなく、「なぜなら～というデータがあるから」「歴史的に見て～という前例がある」のように、説得力のある議論を展開すること。
+    * 他の参加者の意見を尊重しつつ、安易に同調せず、建設的な批判や対案を恐れずに提示すること。
+
+上記を踏まえて、このAIのための最高の「強化ペルソナ設定」を作成してください:
+"""
+
+        try:
+            response = self.client.chat.completions.create(
+                model="gpt-4o",  # 最高性能のモデルでペルソナを設計
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                temperature=0.7,
+            )
+            return response.choices[0].message.content
+        except Exception as e:
+            print(f"ペルソナ強化中にエラー: {e}")
+            return base_persona
+

--- a/core/vector_store_manager.py
+++ b/core/vector_store_manager.py
@@ -1,0 +1,53 @@
+import faiss
+import numpy as np
+from langchain_community.vectorstores import FAISS
+from langchain_openai import OpenAIEmbeddings
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from typing import List, Optional
+
+from .document_processor import DocumentProcessor
+from .config_manager import ConfigManager
+
+
+class VectorStoreManager:
+    """ドキュメントのテキストをベクトル化し、FAISSによる高度な検索機能を提供するクラス。"""
+
+    def __init__(self, openai_api_key: str):
+        self.embeddings = OpenAIEmbeddings(
+            model="text-embedding-3-small", openai_api_key=openai_api_key
+        )
+        self.vector_store: Optional[FAISS] = None
+        self.text_splitter = RecursiveCharacterTextSplitter(
+            chunk_size=1000, chunk_overlap=200
+        )
+        self.config_manager = ConfigManager()
+
+    def create_from_file(self, file_path: str):
+        try:
+            processor = DocumentProcessor(config=self.config_manager.config)
+            result = processor.extract_text(file_path)
+            text = result.extracted_text if result.is_success else ""
+            if not text:
+                self.vector_store = None
+                return
+            chunks = self.text_splitter.split_text(text)
+            self.vector_store = FAISS.from_texts(texts=chunks, embedding=self.embeddings)
+            print("ベクトルストアの構築が完了しました。")
+        except Exception as e:
+            print(f"ベクトルストアの構築中にエラーが発生しました: {e}")
+            self.vector_store = None
+
+    def get_relevant_documents(self, query: str, k: int = 5, use_mmr: bool = False) -> List[str]:
+        """クエリに関連するドキュメントのチャンクを取得する。MMR (Maximal Marginal Relevance) を使用して多様性を確保するオプションを追加。"""
+        if not self.vector_store:
+            return []
+
+        if use_mmr:
+            # MMR検索で、関連性と多様性を両立させる
+            docs = self.vector_store.max_marginal_relevance_search(query, k=k, fetch_k=20)
+        else:
+            # 通常の類似度検索
+            docs = self.vector_store.similarity_search(query, k=k)
+
+        return [doc.page_content for doc in docs]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,7 @@ python-dotenv>=1.0.0  # 環境変数読み込み用
 # その他
 asyncio-throttle>=1.0.2  # API レート制限対応
 pydantic>=2.5.0  # データ検証用
+faiss-cpu
+langchain
+langchain-openai
+langchain_community


### PR DESCRIPTION
## Summary
- add FAISS/langchain dependencies and vector store manager with MMR search
- introduce persona enhancer and context manager for persisting unresolved issues
- extend meeting manager and UI to load/save carry-over context between sessions

## Testing
- `pip install -r requirements.txt`
- `pip install pytest-asyncio`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d77526eb48333b381983e6214f2e4