### PR TITLE
Add carry-over context management helpers and integrate usage

### DIFF
--- a/core/context_manager.py
+++ b/core/context_manager.py
@@ -12,7 +12,7 @@ class ContextManager:
         if not os.path.exists(self.context_dir):
             os.makedirs(self.context_dir)
 
-    def save_carry_over(self, topic: str, unresolved_issues: str):
+    def save_carry_over(self, topic: str, unresolved_issues: str) -> None:
         """未解決の課題をJSONファイルとして保存する。"""
         if not unresolved_issues.strip():
             print("持ち越し事項がないため、保存をスキップしました。")
@@ -57,4 +57,22 @@ class ContextManager:
         with open(filepath, "r", encoding="utf-8") as f:
             data = json.load(f)
             return data.get("unresolved_issues")
+
+
+_default_manager = ContextManager()
+
+
+def save_carry_over(topic: str, unresolved_issues: str) -> None:
+    """持ち越し事項を保存するモジュールレベルのラッパー。"""
+    _default_manager.save_carry_over(topic, unresolved_issues)
+
+
+def list_carry_overs() -> List[Dict[str, str]]:
+    """保存されている持ち越し事項の一覧を返す。"""
+    return _default_manager.list_carry_overs()
+
+
+def load_carry_over(context_id: str) -> Optional[str]:
+    """指定IDの持ち越し事項を読み込む。"""
+    return _default_manager.load_carry_over(context_id)
 

--- a/core/meeting_manager.py
+++ b/core/meeting_manager.py
@@ -16,7 +16,7 @@ from .client_factory import ClientFactory
 from .document_processor import DocumentProcessor
 from .utils import Timer, format_duration, sanitize_filename
 from .config_manager import get_config_manager
-from .context_manager import ContextManager
+from .context_manager import save_carry_over
 from .persona_enhancer import PersonaEnhancer
 
 logger = logging.getLogger(__name__)
@@ -54,7 +54,6 @@ class MeetingManager:
         self.app_config: AppConfig = self.config_manager.config
         self.document_processor = document_processor or DocumentProcessor(config=self.app_config)
         self.carry_over_context = carry_over_context
-        self.context_manager = ContextManager()
         self.participants: Dict[str, ParticipantInfo] = {}
         self.moderator: Optional[ParticipantInfo] = None
         self.state = MeetingState()
@@ -624,7 +623,7 @@ class MeetingManager:
             match = re.search(r"## 4\. 未解決の課題と今後の検討事項\s*\n(.*?)(?=\n##|\Z)", corrected_content, re.DOTALL)
             if match:
                 unresolved_issues = match.group(1).strip()
-                self.context_manager.save_carry_over(user_query, unresolved_issues)
+                save_carry_over(user_query, unresolved_issues)
             return corrected_content
 
         except Exception as e:


### PR DESCRIPTION
## Summary
- expose module-level helpers to save, list, and load carry-over topics
- pass optional carry_over_context into MeetingManager and include in initial context
- extract unresolved issues via regex on final summary and save as carry-over context

## Testing
- `pytest tests/test_meeting_manager.py::test_run_meeting_basic -q` *(hangs; interrupted with KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_688da339a054833387e32c1727fc79b0