### PR TITLE
Fix LangChain community package name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ pydantic>=2.5.0  # データ検証用
 faiss-cpu
 langchain
 langchain-openai
-langchain_community
+langchain-community
 tiktoken>=0.6.0  # トークンカウント用
 
 


### PR DESCRIPTION
## Summary
- correct LangChain community package name in requirements

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_config_manager.py tests/test_context_manager.py tests/test_document_processor.py tests/test_vector_store_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_688db80ef8bc8333a4fcd85bace45f17