### PR TITLE
Add cross-provider summarization helper and tests

### DIFF
--- a/core/document_processor.py
+++ b/core/document_processor.py
@@ -13,7 +13,7 @@ import PyPDF2
 import mammoth
 
 # 独自モジュール
-from .models import FileInfo, DocumentSummary, ModelInfo, AppConfig # AppConfig をインポート
+from .models import FileInfo, DocumentSummary, ModelInfo, AppConfig, AIProvider # AppConfig をインポート
 from .api_clients import BaseAIClient
 from .utils import count_tokens, chunk_text, Timer, sanitize_filename
 
@@ -262,6 +262,51 @@ class DocumentProcessor:
             filename=path.name, filepath=str(path.absolute()),
             file_type=file_type_literal, size_bytes=path.stat().st_size
         )
+
+    def _extract_content_and_tokens(self, provider: AIProvider, response: Any) -> Tuple[str, int]:
+        content = ""
+        tokens_used = 0
+        try:
+            if provider == AIProvider.OPENAI:
+                if response and hasattr(response, 'choices') and response.choices and hasattr(response.choices[0], 'message') and response.choices[0].message:
+                    content = response.choices[0].message.content or ""
+                if response and hasattr(response, 'usage') and response.usage:
+                    tokens_used = getattr(response.usage, 'total_tokens', 0) or 0
+            elif provider == AIProvider.CLAUDE:
+                if response and hasattr(response, 'content') and isinstance(response.content, list) and len(response.content) > 0:
+                    for block in response.content:
+                        if hasattr(block, 'text'):
+                            content = block.text
+                            break
+                if response and hasattr(response, 'usage') and response.usage:
+                    tokens_used = (getattr(response.usage, 'input_tokens', 0) or 0) + (getattr(response.usage, 'output_tokens', 0) or 0)
+            elif provider == AIProvider.GEMINI:
+                if response and hasattr(response, 'candidates') and response.candidates and \
+                   hasattr(response.candidates[0], 'content') and response.candidates[0].content and \
+                   hasattr(response.candidates[0].content, 'parts') and response.candidates[0].content.parts:
+                    content = "".join(part.text for part in response.candidates[0].content.parts if hasattr(part, 'text'))
+
+                if hasattr(response, 'usage_metadata') and response.usage_metadata:
+                    tokens_used = (getattr(response.usage_metadata, 'prompt_token_count', 0) or 0) + \
+                                  (getattr(response.usage_metadata, 'candidates_token_count', 0) or 0)
+                elif hasattr(response, 'usage') and response.usage and hasattr(response.usage, 'total_tokens'):
+                    tokens_used = getattr(response.usage, 'total_tokens', 0) or 0
+                elif hasattr(response, 'usage') and response.usage and hasattr(response.usage, 'prompt_tokens') and hasattr(response.usage, 'completion_tokens'):
+                    tokens_used = (getattr(response.usage, 'prompt_tokens', 0) or 0) + \
+                                   (getattr(response.usage, 'completion_tokens', 0) or 0)
+                else:
+                    if not tokens_used:
+                        logger.warning(f"Geminiのレスポンスからトークン数を取得できませんでした。Response keys: {response.keys() if hasattr(response, 'keys') else type(response)}")
+            else:
+                logger.warning(f"未対応のプロバイダー ({provider}) のため、コンテンツとトークン数を抽出できません。")
+
+        except AttributeError as e:
+            logger.error(f"{provider.value}レスポンスのパース中にAttributeError: {e}. Response: {str(response)[:200]}", exc_info=True)
+            content = "[エラー: レスポンスのパースに失敗]"
+        except Exception as e:
+            logger.error(f"{provider.value}レスポンスのパース中に予期せぬエラー: {e}. Response: {str(response)[:200]}", exc_info=True)
+
+        return content, tokens_used
     
     async def summarize_document_for_meeting(
         self,
@@ -295,9 +340,11 @@ class DocumentProcessor:
                 response = await summarizer_ai_client.request_completion(
                     user_message=prompt, system_message="あなたは専門的な文書要約の専門家です。"
                 )
-                tokens_used_total += response.tokens_used
-                
-                summary = response.content.strip()
+                summary, tokens_used = self._extract_content_and_tokens(
+                    summarizer_ai_client.model_info.provider, response
+                )
+                tokens_used_total += tokens_used
+                summary = summary.strip()
                 summary_length = len(summary)
                 compression_ratio = summary_length / original_length if original_length > 0 else 0.0
                 
@@ -333,18 +380,24 @@ class DocumentProcessor:
             response = await summarizer_ai_client.request_completion(
                 user_message=chunk_prompt, system_message="あなたは文書要約の専門家です。"
             )
-            tokens_used_total += response.tokens_used
-            chunk_summaries.append(response.content.strip())
-            logger.debug(f"チャンク {i + 1}/{len(chunks)} 要約完了 (トークン: {response.tokens_used})")
+            content, tokens_used = self._extract_content_and_tokens(
+                summarizer_ai_client.model_info.provider, response
+            )
+            tokens_used_total += tokens_used
+            chunk_summaries.append(content.strip())
+            logger.debug(f"チャンク {i + 1}/{len(chunks)} 要約完了 (トークン: {tokens_used})")
         
         combined_summaries = "\n\n".join(chunk_summaries)
         final_prompt = self._build_final_summarization_prompt(combined_summaries, target_token_count, style)
         response = await summarizer_ai_client.request_completion(
             user_message=final_prompt, system_message="あなたは文書要約の専門家です。"
         )
-        tokens_used_total += response.tokens_used
-        
-        final_summary = response.content.strip()
+        final_summary, tokens_used = self._extract_content_and_tokens(
+            summarizer_ai_client.model_info.provider, response
+        )
+        tokens_used_total += tokens_used
+
+        final_summary = final_summary.strip()
         summary_length = len(final_summary)
         compression_ratio = summary_length / original_length if original_length > 0 else 0.0
         

--- a/tests/test_document_processor.py
+++ b/tests/test_document_processor.py
@@ -1,5 +1,7 @@
 from core.document_processor import DocumentProcessor
-from core.models import AppConfig
+from core.models import AppConfig, ModelInfo, AIProvider
+from types import SimpleNamespace
+import pytest
 
 
 def test_extract_text_from_txt(tmp_path):
@@ -22,4 +24,58 @@ def test_validate_file_extension(tmp_path):
     valid, err = processor.validate_file(str(file_path))
     assert not valid
     assert "サポートされていない" in err
+
+
+class DummyClient:
+    def __init__(self, provider: AIProvider, response: SimpleNamespace):
+        self.model_info = ModelInfo(name="dummy", provider=provider)
+        self._response = response
+
+    async def request_completion(self, *args, **kwargs):
+        return self._response
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "provider,response,expected_tokens,expected_content",
+    [
+        (
+            AIProvider.OPENAI,
+            SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="openai"))],
+                usage=SimpleNamespace(total_tokens=5),
+            ),
+            5,
+            "openai",
+        ),
+        (
+            AIProvider.CLAUDE,
+            SimpleNamespace(
+                content=[SimpleNamespace(text="claude")],
+                usage=SimpleNamespace(input_tokens=3, output_tokens=4),
+            ),
+            7,
+            "claude",
+        ),
+        (
+            AIProvider.GEMINI,
+            SimpleNamespace(
+                candidates=[
+                    SimpleNamespace(content=SimpleNamespace(parts=[SimpleNamespace(text="gemini")]))
+                ],
+                usage_metadata=SimpleNamespace(prompt_token_count=2, candidates_token_count=3),
+            ),
+            5,
+            "gemini",
+        ),
+    ],
+)
+async def test_summarize_document_for_meeting_with_various_providers(provider, response, expected_tokens, expected_content):
+    config = AppConfig(summarization_target_tokens=10)
+    processor = DocumentProcessor(config)
+    text = "word " * 100
+    client = DummyClient(provider, response)
+    summary = await processor.summarize_document_for_meeting(text, client)
+    assert summary.summary == expected_content
+    assert summary.tokens_used == expected_tokens
 


### PR DESCRIPTION
## Summary
- factor out `_extract_content_and_tokens` in `DocumentProcessor` to normalize provider responses
- use helper after summarization API calls to read content and token usage
- cover OpenAI, Claude, and Gemini document summarization with new tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688de0b318d48333b8088a560c574b62