### PR TITLE
feat: auto-load vector store from disk

### DIFF
--- a/core/vector_store_manager.py
+++ b/core/vector_store_manager.py
@@ -1,8 +1,10 @@
 import faiss  # noqa: F401
 import numpy as np  # noqa: F401
+from pathlib import Path
 from typing import List, Optional
 
 from langchain.docstore.document import Document
+from langchain.embeddings.base import Embeddings
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.vectorstores import FAISS
 from langchain_openai import OpenAIEmbeddings
@@ -14,8 +16,13 @@ from .document_processor import DocumentProcessor
 class VectorStoreManager:
     """ドキュメントのテキストをベクトル化し、FAISSによる高度な検索機能を提供するクラス。"""
 
-    def __init__(self, openai_api_key: str):
-        self.embeddings = OpenAIEmbeddings(
+    def __init__(
+        self,
+        openai_api_key: str,
+        persist_path: Optional[str] = None,
+        embeddings: Optional[Embeddings] = None,
+    ):
+        self.embeddings = embeddings or OpenAIEmbeddings(
             model="text-embedding-3-small", openai_api_key=openai_api_key
         )
         self.vector_store: Optional[FAISS] = None
@@ -23,6 +30,9 @@ class VectorStoreManager:
             chunk_size=1000, chunk_overlap=200
         )
         self.config_manager = ConfigManager()
+
+        if persist_path and Path(persist_path).exists():
+            self.load_from_disk(persist_path)
 
     def create_from_file(self, file_path: str):
         try:

--- a/main.py
+++ b/main.py
@@ -363,13 +363,13 @@ class MultiAIResearchApp:
 
             openai_key = self.config_manager.config.openai_api_key
             if openai_key:
-                self.vector_store_manager = VectorStoreManager(openai_key)
                 store_root = Path("vector_stores")
                 file_hash = generate_file_hash(self.uploaded_file_path)
                 store_path = store_root / file_hash
-                if store_path.exists():
-                    self.vector_store_manager.load_from_disk(str(store_path))
-                else:
+                self.vector_store_manager = VectorStoreManager(
+                    openai_key, str(store_path)
+                )
+                if not self.vector_store_manager.vector_store:
                     await asyncio.to_thread(
                         self.vector_store_manager.create_from_file,
                         self.uploaded_file_path,

--- a/tests/test_vector_store_manager.py
+++ b/tests/test_vector_store_manager.py
@@ -55,8 +55,8 @@ def test_save_and_load(tmp_path):
     save_path = tmp_path / "store"
     manager.save_to_disk(str(save_path))
 
-    new_manager = VectorStoreManager(openai_api_key="test")
-    new_manager.embeddings = fake
-    new_manager.load_from_disk(str(save_path))
+    new_manager = VectorStoreManager(
+        openai_api_key="test", persist_path=str(save_path), embeddings=fake
+    )
     results = new_manager.get_relevant_documents("hello", k=1)
     assert results == ["hello world"]


### PR DESCRIPTION
## Summary
- allow VectorStoreManager to automatically load FAISS indexes from disk
- persist vector store when processing files and reuse existing indexes
- update tests to exercise persistence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688df3ee0be48333a5ebf25eb67a636b