### PR TITLE
feat: persist and load vector store

### DIFF
--- a/main.py
+++ b/main.py
@@ -374,8 +374,7 @@ class MultiAIResearchApp:
                         self.vector_store_manager.create_from_file,
                         self.uploaded_file_path,
                     )
-                    store_path.mkdir(parents=True, exist_ok=True)
-                    self.vector_store_manager.save_to_disk(str(store_path))
+                    self.vector_store_manager.save_to_disk()
             else:
                 logger.warning("OpenAI APIキーが設定されていないため、ベクトルストアを構築できません。")
                 self.vector_store_manager = None

--- a/tests/test_vector_store_manager.py
+++ b/tests/test_vector_store_manager.py
@@ -47,13 +47,14 @@ class FakeEmbeddings(Embeddings):
 
 
 def test_save_and_load(tmp_path):
-    manager = VectorStoreManager(openai_api_key="test")
+    save_path = tmp_path / "store"
     fake = FakeEmbeddings()
-    manager.embeddings = fake
+    manager = VectorStoreManager(
+        openai_api_key="test", persist_path=str(save_path), embeddings=fake
+    )
     texts = ["hello world", "foo bar"]
     manager.vector_store = FAISS.from_texts(texts, embedding=fake)
-    save_path = tmp_path / "store"
-    manager.save_to_disk(str(save_path))
+    manager.save_to_disk()
 
     new_manager = VectorStoreManager(
         openai_api_key="test", persist_path=str(save_path), embeddings=fake


### PR DESCRIPTION
## Summary
- allow VectorStoreManager to persist FAISS stores and reload automatically
- load existing vector stores on file selection
- cover save/load path handling with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688df69dd14083338016e09701bd2df6