### PR TITLE
Handle corrupted context files

### DIFF
--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -22,3 +22,21 @@ def test_save_list_load(tmp_path, monkeypatch):
 
     loaded = manager.load_carry_over(context["id"])
     assert loaded == "unresolved items"
+
+
+def test_skip_and_remove_invalid(tmp_path, monkeypatch):
+    monkeypatch.setattr("core.context_manager.datetime", FixedDateTime)
+    manager = ContextManager(context_dir=str(tmp_path))
+
+    manager.save_carry_over("topic", "issue")
+
+    invalid_file = tmp_path / "invalid.json"
+    invalid_file.write_text("{invalid", encoding="utf-8")
+
+    contexts = manager.list_carry_overs()
+    assert len(contexts) == 1
+    assert invalid_file.exists()
+
+    contexts = manager.list_carry_overs(remove_invalid=True)
+    assert len(contexts) == 1
+    assert not invalid_file.exists()


### PR DESCRIPTION
## Summary
- Clean up corrupted context JSON files on `ContextManager` initialization
- Allow `list_carry_overs` to optionally delete invalid context files
- Test skipping and removing invalid context files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dfaef07148333bd9d1a742af657e7