### PR TITLE
Handle invalid carry-over files gracefully

### DIFF
--- a/core/context_manager.py
+++ b/core/context_manager.py
@@ -88,9 +88,17 @@ class ContextManager:
         filepath = os.path.join(self.context_dir, context_id)
         if not os.path.exists(filepath):
             return None
-        with open(filepath, "r", encoding="utf-8") as f:
-            data = json.load(f)
+        try:
+            with open(filepath, "r", encoding="utf-8") as f:
+                data = json.load(f)
             return data.get("unresolved_issues")
+        except (json.JSONDecodeError, OSError):
+            # ファイルが壊れている場合は削除してNoneを返す
+            try:
+                os.remove(filepath)
+            except OSError:
+                pass
+            return None
 
 
 _default_manager = ContextManager()

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -40,3 +40,12 @@ def test_skip_and_remove_invalid(tmp_path, monkeypatch):
     contexts = manager.list_carry_overs(remove_invalid=True)
     assert len(contexts) == 1
     assert not invalid_file.exists()
+
+
+def test_load_invalid_file_returns_none_and_removes(tmp_path):
+    manager = ContextManager(context_dir=str(tmp_path))
+    bad = tmp_path / "bad.json"
+    bad.write_text("{bad", encoding="utf-8")
+
+    assert manager.load_carry_over("bad.json") is None
+    assert not bad.exists()


### PR DESCRIPTION
## Summary
- Cleanly handle corrupted carry-over files by deleting and returning `None` during load
- Test context manager behavior when loading malformed JSON files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e130921b8833399c3c2ec6e9b5699