### PR TITLE
chore: remove unused imports

### DIFF
--- a/core/vector_store_manager.py
+++ b/core/vector_store_manager.py
@@ -1,5 +1,3 @@
-import faiss  # noqa: F401
-import numpy as np  # noqa: F401
 from pathlib import Path
 from typing import List, Optional
 


### PR DESCRIPTION
## Summary
- remove unused faiss and numpy imports from vector store manager

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_config_manager.py tests/test_context_manager.py tests/test_document_processor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688e27e5d1e8833389e0207f32d5294b