### PR TITLE
Use logger and secure FAISS deserialization

### DIFF
--- a/tests/test_vector_store_manager.py
+++ b/tests/test_vector_store_manager.py
@@ -57,7 +57,10 @@ def test_save_and_load(tmp_path):
     manager.save_to_disk()
 
     new_manager = VectorStoreManager(
-        openai_api_key="test", persist_path=str(save_path), embeddings=fake
+        openai_api_key="test",
+        persist_path=str(save_path),
+        embeddings=fake,
+        allow_dangerous_deserialization=True,
     )
     results = new_manager.get_relevant_documents("hello", k=1)
     assert results == ["hello world"]


### PR DESCRIPTION
## Summary
- replace `print` statements in the vector store manager with `logging` calls and record exceptions via `logger.exception`
- parameterize FAISS deserialization to default to safe behavior and require explicit approval for dangerous deserialization
- adjust vector store manager tests for the new deserialization flag

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e2e7c27fc8333992f18ab90c8c04c