### PR TITLE
refactor: centralize response parsing

### DIFF
--- a/tests/test_document_processor.py
+++ b/tests/test_document_processor.py
@@ -1,5 +1,6 @@
 from core.document_processor import DocumentProcessor
 from core.models import AppConfig, ModelInfo, AIProvider
+from core.utils import extract_content_and_tokens
 from types import SimpleNamespace
 import pytest
 
@@ -75,8 +76,7 @@ class DummyClient:
     TEST_CASES,
 )
 def test_extract_content_and_tokens(provider, response, expected_tokens, expected_content):
-    processor = DocumentProcessor(AppConfig())
-    content, tokens = processor._extract_content_and_tokens(provider, response)
+    content, tokens = extract_content_and_tokens(provider, response)
     assert content == expected_content
     assert tokens == expected_tokens
 

--- a/tests/test_meeting_manager.py
+++ b/tests/test_meeting_manager.py
@@ -202,7 +202,7 @@ async def test_carry_over_created(tmp_path, monkeypatch):
     async def fake_ensure(content, client, provider, context_for_correction):
         return content, 0
 
-    monkeypatch.setattr(manager, "_extract_content_and_tokens", fake_extract)
+    monkeypatch.setattr(meeting_manager, "extract_content_and_tokens", fake_extract)
     monkeypatch.setattr(manager, "_ensure_japanese_output", fake_ensure)
     monkeypatch.setattr(manager, "_format_conversation_for_summary", lambda: "log")
     monkeypatch.setattr(manager, "_build_summary_prompt", lambda u, c, d: "prompt")


### PR DESCRIPTION
## Summary
- add `extract_content_and_tokens` utility to parse AI responses consistently
- use shared utility in `DocumentProcessor` and `MeetingManager` instead of duplicating logic
- update tests for new utility

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ecf24aedc83338e8c68f5836b0c1d