### PR TITLE
refactor: organize imports

### DIFF
--- a/core/vector_store_manager.py
+++ b/core/vector_store_manager.py
@@ -1,7 +1,7 @@
 from pathlib import Path
+import logging
 from typing import List, Optional
 
-import logging
 from langchain.docstore.document import Document
 from langchain.embeddings.base import Embeddings
 from langchain.text_splitter import RecursiveCharacterTextSplitter


### PR DESCRIPTION
## Summary
- group standard library imports in vector store manager
- ensure `Path` from `pathlib` is imported

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ede1cda7483338810f2eedb8097a1