### PR TITLE
Add summary length field to DocumentSummary

### DIFF
--- a/tests/test_document_processor.py
+++ b/tests/test_document_processor.py
@@ -94,4 +94,5 @@ async def test_summarize_document_for_meeting_with_various_providers(provider, r
     summary = await processor.summarize_document_for_meeting(text, client)
     assert summary.summary == expected_content
     assert summary.tokens_used == expected_tokens
+    assert summary.summary_length == len(expected_content)
 


### PR DESCRIPTION
## Summary
- include `summary_length` in `DocumentSummary` with automatic population from `summary`
- compute compression ratio using `summary_length`
- verify `summary_length` in document summarization tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ee21afb6483338018b2285e7e42d3