### PR TITLE
Refactor ClientFactory create_client to use cls parameter

### DIFF
--- a/core/client_factory.py
+++ b/core/client_factory.py
@@ -19,13 +19,13 @@ class ClientFactory:
 
     @classmethod
     def create_client(
-        self,
+        cls,
         model_info: ModelInfo,
         api_key: Optional[str] = None,
-        **kwargs: Any 
+        **kwargs: Any
     ) -> BaseAIClient:
         provider = model_info.provider
-        if provider not in self._client_classes:
+        if provider not in cls._client_classes:
             logger.error(f"サポートされていないプロバイダー試行: {provider}")
             raise ValueError(f"サポートされていないプロバイダー: {provider}")
 
@@ -38,10 +38,10 @@ class ClientFactory:
                 logger.error(f"{provider.value} APIキーが設定されていません (ConfigManagerから取得失敗)")
                 raise RuntimeError(f"{provider.value} APIキーが設定されていません")
 
-        client_class = self._client_classes[provider]
-        
+        client_class = cls._client_classes[provider]
+
         # プロバイダー固有のデフォルト引数を AppConfig から取得
-        default_provider_kwargs = self._get_default_kwargs_from_config(provider, app_config)
+        default_provider_kwargs = cls._get_default_kwargs_from_config(provider, app_config)
         
         # 渡されたkwargsでデフォルトを上書き
         final_kwargs = {**default_provider_kwargs, **kwargs}


### PR DESCRIPTION
## Summary
- fix ClientFactory.create_client to accept `cls` instead of `self`
- update internal references to class attributes accordingly

## Testing
- `flake8 core/client_factory.py` *(fails: E261, E501 and other warnings)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ef31f32a48333b551012c1e275f11