### PR TITLE
chore: remove unused imports from document processor

### DIFF
--- a/core/document_processor.py
+++ b/core/document_processor.py
@@ -1,4 +1,3 @@
-import os
 import re
 import logging
 from pathlib import Path
@@ -15,7 +14,7 @@ import mammoth
 # 独自モジュール
 from .models import FileInfo, DocumentSummary, ModelInfo, AppConfig, AIProvider # AppConfig をインポート
 from .api_clients import BaseAIClient
-from .utils import count_tokens, chunk_text, Timer, sanitize_filename, extract_content_and_tokens
+from .utils import count_tokens, chunk_text, Timer, extract_content_and_tokens
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- remove unused `os` and `sanitize_filename` imports from document processor

## Testing
- `flake8 core/document_processor.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f27ef79c48333bdf3f50edafc8b46