### PR TITLE
feat: allow injecting shared ConfigManager into VectorStoreManager

### DIFF
--- a/core/vector_store_manager.py
+++ b/core/vector_store_manager.py
@@ -8,7 +8,7 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.vectorstores import FAISS
 from langchain_openai import OpenAIEmbeddings
 
-from .config_manager import ConfigManager
+from .config_manager import ConfigManager, get_config_manager
 from .document_processor import DocumentProcessor
 
 
@@ -24,6 +24,7 @@ class VectorStoreManager:
         persist_path: Optional[str] = None,
         embeddings: Optional[Embeddings] = None,
         allow_dangerous_deserialization: bool = False,
+        config_manager: Optional[ConfigManager] = None,
     ):
         self.embeddings = embeddings or OpenAIEmbeddings(
             model="text-embedding-3-small", openai_api_key=openai_api_key
@@ -33,7 +34,7 @@ class VectorStoreManager:
         self.text_splitter = RecursiveCharacterTextSplitter(
             chunk_size=1000, chunk_overlap=200
         )
-        self.config_manager = ConfigManager()
+        self.config_manager = config_manager or get_config_manager()
 
         if self.persist_path and Path(self.persist_path).exists():
             self.load_from_disk(

--- a/main.py
+++ b/main.py
@@ -386,7 +386,7 @@ class MultiAIResearchApp:
                 file_hash = generate_file_hash(self.uploaded_file_path)
                 store_path = store_root / file_hash
                 self.vector_store_manager = VectorStoreManager(
-                    openai_key, str(store_path)
+                    openai_key, str(store_path), config_manager=self.config_manager
                 )
                 if not self.vector_store_manager.vector_store:
                     await asyncio.to_thread(

--- a/tests/test_vector_store_manager.py
+++ b/tests/test_vector_store_manager.py
@@ -3,6 +3,7 @@ from langchain.docstore.document import Document
 from langchain_community.vectorstores import FAISS
 from langchain.embeddings.base import Embeddings
 
+from core.config_manager import get_config_manager
 from core.vector_store_manager import VectorStoreManager
 
 
@@ -19,7 +20,7 @@ class DummyVectorStore:
 
 
 def test_mmr_diversity_and_reproducibility():
-    manager = VectorStoreManager(openai_api_key="test")
+    manager = VectorStoreManager(openai_api_key="test", config_manager=get_config_manager())
     manager.vector_store = DummyVectorStore()
 
     # Similarity search produces duplicate results


### PR DESCRIPTION
## Summary
- allow VectorStoreManager to accept an optional `ConfigManager` and default to `get_config_manager`
- pass shared ConfigManager instance in main entry
- adjust vector store tests to use shared ConfigManager

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f4975491083338a21a8d350602a22