### PR TITLE
refactor: remove unused app variable in main

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,7 +51,7 @@ class MultiAIResearchApp(ComponentsMixin, EventsMixin):
 
 
 async def main(page: ft.Page):
-    app = MultiAIResearchApp(page)
+    MultiAIResearchApp(page)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- simplify `main` coroutine by instantiating `MultiAIResearchApp` without unused variable

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f6ea0774083339c3a8634ae80694a