### PR TITLE
Remove unused List import from document_processor

### DIFF
--- a/core/document_processor.py
+++ b/core/document_processor.py
@@ -3,7 +3,7 @@ import re
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import docx
 import mammoth


### PR DESCRIPTION
## Summary
- remove unused `List` import from `typing` in `core/document_processor.py`
- confirm no remaining references to `List`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f721c5d748333b7d59be19a400221