### PR TITLE
refactor: remove unused variable from summary formatting

### DIFF
--- a/core/meeting_manager.py
+++ b/core/meeting_manager.py
@@ -632,7 +632,6 @@ class MeetingManager:
             return f"（最終要約生成エラー: {type(e).__name__} が発生しました。詳細はログを確認してください。）"
 
     def _format_conversation_for_summary(self) -> str:
-        formatted_lines = []
         if not self.state.conversation_history: return "（会議中に発言はありませんでした）"
 
         max_tokens = self.app_config.summary_conversation_log_max_tokens


### PR DESCRIPTION
## Summary
- drop unused `formatted_lines` in `_format_conversation_for_summary`
- retain conversation log formatting

## Testing
- `pytest`
- manually invoked `_format_conversation_for_summary` to verify output


------
https://chatgpt.com/codex/tasks/task_e_688f75bc804c8333b84ba4f903ccdec3