### PR TITLE
chore: remove unused imports

### DIFF
--- a/core/api_clients/base_client.py
+++ b/core/api_clients/base_client.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from abc import ABC, abstractmethod
 from typing import Optional, List, Dict, Any

--- a/core/api_clients/claude_client.py
+++ b/core/api_clients/claude_client.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any
 import httpx
 import anthropic
 from anthropic import APITimeoutError, APIConnectionError, RateLimitError, APIStatusError

--- a/core/api_clients/gemini_client.py
+++ b/core/api_clients/gemini_client.py
@@ -4,7 +4,7 @@ from typing import List, Dict, Any, Optional
 import google.generativeai as genai
 # Content と Part の直接インポートを削除 (またはコメントアウト)
 # from google.generativeai.types import Content, Part
-from google.generativeai.types import GenerationConfig, HarmCategory, HarmBlockThreshold # これらは通常存在
+from google.generativeai.types import HarmCategory, HarmBlockThreshold # これらは通常存在
 from google.api_core import exceptions as google_exceptions
 
 from .base_client import BaseAIClient

--- a/core/api_clients/openai_client.py
+++ b/core/api_clients/openai_client.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any
 import httpx
 from openai import AsyncOpenAI, APITimeoutError as OpenAPITimeoutError, APIConnectionError as OpenAIAPIConnectionError, APIStatusError as OpenAIAPIStatusError, RateLimitError as OpenAPIRateLimitError
 

--- a/core/models.py
+++ b/core/models.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any, Literal
+from typing import Optional, List, Literal
 from pydantic import BaseModel, Field, field_validator, ConfigDict, ValidationInfo
 from enum import Enum
 from datetime import datetime

--- a/core/utils.py
+++ b/core/utils.py
@@ -9,7 +9,7 @@ import time
 import hashlib
 import json
 from datetime import datetime
-from typing import Optional, List, Dict, Any, Callable, TypeVar, Tuple
+from typing import List, Dict, Any, Callable, TypeVar, Tuple
 from pathlib import Path
 import logging
 from functools import wraps

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,5 +1,4 @@
 import json
-import os
 from core.config_manager import ConfigManager
 
 

--- a/tests/test_vector_store_manager.py
+++ b/tests/test_vector_store_manager.py
@@ -1,4 +1,3 @@
-import pytest
 from langchain.docstore.document import Document
 from langchain_community.vectorstores import FAISS
 from langchain.embeddings.base import Embeddings


### PR DESCRIPTION
## Summary
- clean up unused imports across core modules and tests
- run pyflakes to confirm no unused imports remain

## Testing
- `pyflakes $(git ls-files '*.py' | grep -v temp_fix.py)`

------
https://chatgpt.com/codex/tasks/task_e_688f7cd85adc8333a8a7d27d8958c457