### PR TITLE
fix: update Flet color API usage

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,14 +1,16 @@
 import flet as ft
 
+
 def main(page: ft.Page):
     try:
-        c = ft.colors.PRIMARY
-        t = ft.Text(f"Primary color is: {c}", color=ft.colors.GREEN)
+        c = ft.Colors.PRIMARY
+        t = ft.Text(f"Primary color is: {c}", color=ft.Colors.GREEN)
         page.add(t)
         page.update()
-        print("ft.colors seems to be working.")
+        print("ft.Colors seems to be working.")
     except AttributeError as e:
-        print(f"Error accessing ft.colors: {e}")
+        print(f"Error accessing ft.Colors: {e}")
+
 
 if __name__ == "__main__":
     ft.app(target=main)

--- a/ui/components.py
+++ b/ui/components.py
@@ -63,7 +63,7 @@ class ComponentsMixin:
         self.carry_over_info_text = ft.Text("", size=12)
         self.carry_over_banner = ft.Container(
             content=self.carry_over_info_text,
-            bgcolor=ft.colors.AMBER_100,
+            bgcolor=ft.Colors.AMBER_100,
             padding=ft.padding.symmetric(vertical=5, horizontal=10),
             border_radius=5,
             visible=False,


### PR DESCRIPTION
## Summary
- replace deprecated `ft.colors` usage with `ft.Colors`
- adjust sample test script accordingly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68901f71a850833383fb1b18f974719b